### PR TITLE
Update AttributeEvents.php

### DIFF
--- a/src/AttributeEvents.php
+++ b/src/AttributeEvents.php
@@ -55,7 +55,7 @@ trait AttributeEvents
                 continue; // Not changed
             }
             
-            if ($value instanceof \UnitEnum) {
+            if ($value instanceof \BackedEnum) {
                 $value = $this->getEnumCastableAttributeValue($attribute, $value)->value;
             }
 

--- a/src/AttributeEvents.php
+++ b/src/AttributeEvents.php
@@ -54,6 +54,10 @@ trait AttributeEvents
             elseif (!$this->isDirty($attribute)) {
                 continue; // Not changed
             }
+            
+            if ($value instanceof \UnitEnum) {
+                $value = $this->getEnumCastableAttributeValue($attribute, $value)->value;
+            }
 
             if (
                 $expected === '*'


### PR DESCRIPTION
Add support for PHP 8.1 Enums by converting the value to a string if the attribute is casted to a backed enum.

Related: https://github.com/jpkleemans/attribute-events/issues/11