### PR TITLE
Fix: don't attempt casting enums to string

### DIFF
--- a/src/AttributeEvents.php
+++ b/src/AttributeEvents.php
@@ -54,18 +54,27 @@ trait AttributeEvents
                 continue; // Not changed
             }
 
-            if (
-                $expected === '*'
-                || $value instanceof \UnitEnum && ($value->name === $expected)
-                || $expected === 'true' && $value === true
-                || $expected === 'false' && $value === false
-                || is_numeric($expected) && Str::contains($expected, '.') && $value === (float) $expected // float
-                || is_numeric($expected) && $value === (int) $expected // int
-                || (string) $value === $expected
-            ) {
+            if ($this->shouldFireEvent($value, $expected)) {
                 $this->fireModelEvent($change, false);
             }
         }
+    }
+
+    private function shouldFireEvent($value, $expected): bool
+    {
+        if ($expected === '*') {
+            return true;
+        }
+
+        if ($value instanceof \UnitEnum) {
+            return $value->name === $expected;
+        }
+
+        return $expected === 'true' && $value === true
+            || $expected === 'false' && $value === false
+            || is_numeric($expected) && Str::contains($expected, '.') && $value === (float) $expected // float
+            || is_numeric($expected) && $value === (int) $expected // int
+            || (string) $value === $expected;
     }
 
     private function syncOriginalAccessors(): void

--- a/tests/AttributeEventsTest.php
+++ b/tests/AttributeEventsTest.php
@@ -407,6 +407,20 @@ class AttributeEventsTest extends TestCase
         $this->dispatcher->assertDispatched(Fake\Events\EnumOrderShipped::class);
     }
 
+    /** @test */
+    public function it_ignores_non_matching_enums()
+    {
+        $order = new Fake\Order();
+        $order->status_enum = OrderStatus::PROCESSING;
+        $order->save();
+
+        $order = Fake\Order::find($order->id);
+        $order->status_enum = OrderStatus::CANCELLED;
+        $order->save();
+
+        $this->dispatcher->assertNotDispatched(Fake\Events\EnumOrderShipped::class);
+    }
+
     // Setup methods
 
     private function initEventDispatcher()


### PR DESCRIPTION
This will end up with a fatal error. 

I extracted `shouldFireEvent()` method that will determine whether the event should be fired.
It will check the name for enums but won't fall back to other comparison methods.