### PR TITLE
Add a check before casting $value to string when firing events

### DIFF
--- a/src/AttributeEvents.php
+++ b/src/AttributeEvents.php
@@ -61,7 +61,7 @@ trait AttributeEvents
                 || $expected === 'false' && $value === false
                 || is_numeric($expected) && Str::contains($expected, '.') && $value === (float) $expected // float
                 || is_numeric($expected) && $value === (int) $expected // int
-                || (string) $value === $expected
+                || $this->canBeCastedToString($value) && (string) $value === $expected
             ) {
                 $this->fireModelEvent($change, false);
             }
@@ -136,5 +136,17 @@ trait AttributeEvents
         }
 
         return false;
+    }
+
+    private function canBeCastedToString($value): bool
+    {
+        if ($value instanceof \UnitEnum) {
+            return false;
+        }
+
+        return is_scalar($value)
+            || is_null($value)
+            || is_array($value)
+            || is_object($value) && method_exists($value, '__toString');
     }
 }


### PR DESCRIPTION
Firstly, I want to express my gratitude for your contribution to this library. Secondly, I appreciate @patrocle for investigating the issue and suggesting a solution in #16.

As @patrocle did not return to his pull request to address the test failures, I incorporated his code and made enhancements to resolve the issue without compromising the test results.

If you have any suggestions for code improvements or any other matters, please feel free to contact me.

Additionally, could you please add the [hacktoberfest label](https://hacktoberfest.com/participation/#pr-mr-details:~:text=%5BPARTICIPATING%5D%20YOUR%20PR/MRS%20MUST%20BE%20IN%20A%20REPO%20TAGGED%20WITH%20THE%20%E2%80%9CHACKTOBERFEST%E2%80%9D%20TOPIC%2C%20OR%20HAVE%20THE%20%E2%80%9CHACKTOBERFEST%2DACCEPTED%E2%80%9D%20LABEL.) to this pull request?

Thank you!