### PR TITLE
feat: support strict models by handling `MissingAttributeException`

### DIFF
--- a/tests/AttributeEventsTest.php
+++ b/tests/AttributeEventsTest.php
@@ -38,6 +38,8 @@ class AttributeEventsTest extends TestCase
     {
         $this->initEventDispatcher();
         $this->initDatabase();
+
+        Model::shouldBeStrict();
     }
 
     public function test_it_still_dispatches_native_events(): void


### PR DESCRIPTION
This update ensures compatibility with Laravel's `Model::shouldBeStrict()` feature.

For example, the following code may throw a `MissingAttributeException` if any defined attribute event attributes are not fetched:

```php
Order::query()->pluck('status', 'id');
```

To address this, each `getAttribute()` call is now wrapped in a try-catch block, preventing exceptions and maintaining functionality in strict mode.